### PR TITLE
add multi-item scoring

### DIFF
--- a/aot_build_utils/literal_map.py
+++ b/aot_build_utils/literal_map.py
@@ -18,6 +18,7 @@ mask_mode_literal = {
     0: "MaskMode::kNone",
     1: "MaskMode::kCausal",
     2: "MaskMode::kCustom",
+    3: "MaskMode::kMultiItemScoring"
 }
 
 pos_encoding_mode_literal = {

--- a/aot_build_utils/literal_map.py
+++ b/aot_build_utils/literal_map.py
@@ -18,7 +18,7 @@ mask_mode_literal = {
     0: "MaskMode::kNone",
     1: "MaskMode::kCausal",
     2: "MaskMode::kCustom",
-    3: "MaskMode::kMultiItemScoring"
+    3: "MaskMode::kMultiItemScoring",
 }
 
 pos_encoding_mode_literal = {

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -45,8 +45,9 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -58,8 +59,10 @@ at::Tensor BatchPrefillWithKVCachePlan(
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
   // Check if the optional values have a value before accessing them
   auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
-  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
-  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* token_pos_in_items_p =
+      token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v =
+      token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
   auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
   cudaError_t status = PrefillPlan<IdType>(
       float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
@@ -184,7 +187,8 @@ void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
 
         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
@@ -325,7 +329,8 @@ void BatchPrefillWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
 
         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -45,7 +45,8 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal) {
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -55,12 +56,18 @@ at::Tensor BatchPrefillWithKVCachePlan(
 
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  // Check if the optional values have a value before accessing them
+  auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
+  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
   cudaError_t status = PrefillPlan<IdType>(
       float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
       kv_indptr.data_ptr<IdType>(), total_num_rows, batch_size, num_qo_heads, num_kv_heads,
-      head_dim_qk, head_dim_vo, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream);
+      head_dim_qk, head_dim_vo, page_size, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream,
+      prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
 
   TORCH_CHECK(status == cudaSuccess,
               "Failed to plan prefill with error: ", cudaGetErrorString(status));
@@ -174,6 +181,13 @@ void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
         }
         params.padded_batch_size = plan_info.padded_batch_size;
         params.max_total_num_rows = plan_info.total_num_rows;
+
+        // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
+
         if (plan_info.enable_cuda_graph) {
           params.total_num_rows =
               GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
@@ -308,6 +322,13 @@ void BatchPrefillWithPagedKVCacheRun(at::Tensor float_workspace_buffer,
         }
         params.padded_batch_size = plan_info.padded_batch_size;
         params.max_total_num_rows = plan_info.total_num_rows;
+
+        // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
+
         if (plan_info.enable_cuda_graph) {
           params.total_num_rows =
               GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);

--- a/csrc/batch_prefill_customize_config.jinja
+++ b/csrc/batch_prefill_customize_config.jinja
@@ -68,6 +68,10 @@ struct RaggedParams {
   uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];
@@ -108,6 +112,10 @@ struct PagedParams {
   uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];

--- a/csrc/batch_prefill_jit_pybind.cu
+++ b/csrc/batch_prefill_jit_pybind.cu
@@ -21,7 +21,8 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/batch_prefill_jit_pybind.cu
+++ b/csrc/batch_prefill_jit_pybind.cu
@@ -21,8 +21,9 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -43,8 +43,9 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -54,10 +55,12 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
 
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
-   // Check if the optional values have a value before accessing them
+  // Check if the optional values have a value before accessing them
   auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
-  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
-  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* token_pos_in_items_p =
+      token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v =
+      token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
   auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
 
   cudaError_t status =
@@ -66,8 +69,8 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
                       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
                       kv_indptr.data_ptr<IdType>(), kv_len_arr.data_ptr<IdType>(), total_num_rows,
                       batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
-                      causal, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream,
-                      prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
+                      causal, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream, prefix_len_p,
+                      token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
 
   TORCH_CHECK(status == cudaSuccess,
               "PrefillSM90Plan failed with error: ", cudaGetErrorString(status));
@@ -153,7 +156,8 @@ void BatchPrefillWithRaggedKVCacheSM90Run(at::Tensor float_workspace_buffer,
 
         // Set the multi-item scoring parameters
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
@@ -259,7 +263,8 @@ void BatchPrefillWithPagedKVCacheSM90Run(
 
         // Set the multi-item scoring parameters
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -43,7 +43,8 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal) {
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * float_workspace_buffer.element_size();
   size_t int_workspace_size_in_bytes =
@@ -53,6 +54,11 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
 
   const c10::cuda::OptionalCUDAGuard device_guard(float_workspace_buffer.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+   // Check if the optional values have a value before accessing them
+  auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
+  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
 
   cudaError_t status =
       PrefillSM90Plan(float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
@@ -60,7 +66,8 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
                       int_workspace_size_in_bytes, plan_info, qo_indptr.data_ptr<IdType>(),
                       kv_indptr.data_ptr<IdType>(), kv_len_arr.data_ptr<IdType>(), total_num_rows,
                       batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
-                      causal, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream);
+                      causal, enable_cuda_graph, /*sizeof_dtype_o=*/2, stream,
+                      prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
 
   TORCH_CHECK(status == cudaSuccess,
               "PrefillSM90Plan failed with error: ", cudaGetErrorString(status));
@@ -141,6 +148,14 @@ void BatchPrefillWithRaggedKVCacheSM90Run(at::Tensor float_workspace_buffer,
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
         params.work_indptr =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+        params.batch_indices =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.batch_indices_offset);
+
+        // Set the multi-item scoring parameters
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 
@@ -238,7 +253,15 @@ void BatchPrefillWithPagedKVCacheSM90Run(
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
         params.work_indptr =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+        params.batch_indices =
+            GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.batch_indices_offset);
         params.kv_indices = static_cast<IdType*>(paged_kv_indices.data_ptr());
+
+        // Set the multi-item scoring parameters
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 

--- a/csrc/batch_prefill_sm90_customize_config.jinja
+++ b/csrc/batch_prefill_sm90_customize_config.jinja
@@ -43,6 +43,7 @@ struct RaggedParams {
   IdType* kv_lens;
   IdType* head_indices;
   IdType* work_indptr;
+  IdType* batch_indices;
 
   struct AdditionalParams {
     {{ additional_params_decl }}
@@ -66,6 +67,11 @@ struct RaggedParams {
   int window_left;
 
   bool causal;
+
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 };
 
 struct PagedParams {
@@ -88,6 +94,7 @@ struct PagedParams {
   IdType* kv_lens;
   IdType* head_indices;
   IdType* work_indptr;
+  IdType* batch_indices;
 
   struct AdditionalParams {
     {{ additional_params_decl }}
@@ -111,6 +118,11 @@ struct PagedParams {
   int window_left;
 
   bool causal;
+
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 };
 
 {{ variant_decl }}

--- a/csrc/batch_prefill_sm90_jit_pybind.cu
+++ b/csrc/batch_prefill_sm90_jit_pybind.cu
@@ -21,7 +21,8 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(at::Tensor float_workspace_buffer,
                                           at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/batch_prefill_sm90_jit_pybind.cu
+++ b/csrc/batch_prefill_sm90_jit_pybind.cu
@@ -21,8 +21,9 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(at::Tensor float_workspace_buffer,
                                           at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -105,8 +105,9 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/flashinfer_ops.cu
+++ b/csrc/flashinfer_ops.cu
@@ -105,7 +105,8 @@ at::Tensor BatchPrefillWithKVCachePlan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(at::Tensor float_workspace_buffer,
                                       at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -32,8 +32,9 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr,
+    std::optional<at::Tensor> token_pos_in_items_ptr, std::optional<int64_t> token_pos_in_items_len,
+    std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/csrc/flashinfer_ops_sm90.cu
+++ b/csrc/flashinfer_ops_sm90.cu
@@ -32,7 +32,8 @@ at::Tensor BatchPrefillWithKVCacheSM90Plan(
     at::Tensor page_locked_int_workspace_buffer, at::Tensor qo_indptr, at::Tensor kv_indptr,
     at::Tensor kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal);
+    int64_t head_dim_vo, bool causal, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer, at::Tensor plan_info_vec,

--- a/flashinfer/jit/attention/pytorch.py
+++ b/flashinfer/jit/attention/pytorch.py
@@ -629,8 +629,8 @@ def gen_customize_pod_module(
 
     source_paths = []
 
-    for mask_mode_p in [0, 1, 2]:
-        for mask_mode_d in [0, 1, 2]:
+    for mask_mode_p in [0, 1, 2, 3]:
+        for mask_mode_d in [0, 1, 2, 3]:
             kwargs["mask_mode_p"] = mask_mode_literal[mask_mode_p]
             kwargs["mask_mode_d"] = mask_mode_literal[mask_mode_d]
 
@@ -929,7 +929,7 @@ def gen_customize_single_prefill_module(
         os.makedirs(gen_directory, exist_ok=True)
 
         source_paths = []
-        for mask_mode in [0, 1, 2]:
+        for mask_mode in [0, 1, 2, 3]:
             filename = f"single_prefill_kernel_mask_{mask_mode}.cu"
             dest_path = gen_directory / filename
             source_paths.append(dest_path)
@@ -987,7 +987,7 @@ def gen_customize_single_prefill_module(
         os.makedirs(gen_directory, exist_ok=True)
 
         source_paths = []
-        for mask_mode in [0, 1, 2]:
+        for mask_mode in [0, 1, 2, 3]:
             filename = f"single_prefill_sm90_kernel_mask_{mask_mode}.cu"
             dest_path = gen_directory / filename
             source_paths.append(dest_path)
@@ -1170,7 +1170,7 @@ def gen_customize_batch_prefill_module(
         os.makedirs(gen_directory, exist_ok=True)
 
         source_paths = []
-        for mask_mode in [0, 1, 2]:
+        for mask_mode in [0, 1, 2, 3]:
             dest_path = (
                 gen_directory / f"batch_prefill_paged_kernel_mask_{mask_mode}.cu"
             )
@@ -1243,7 +1243,7 @@ def gen_customize_batch_prefill_module(
         generated_inc_str = config_templ.render(**kwargs)
 
         source_paths = []
-        for mask_mode in [0, 1, 2]:
+        for mask_mode in [0, 1, 2, 3]:
             filename = f"batch_prefill_paged_sm90_kernel_mask_{mask_mode}.cu"
             dest_path = gen_directory / filename
             source_paths.append(dest_path)

--- a/flashinfer/jit/utils.py
+++ b/flashinfer/jit/utils.py
@@ -98,4 +98,5 @@ mask_mode_literal = {
     0: "MaskMode::kNone",
     1: "MaskMode::kCausal",
     2: "MaskMode::kCustom",
+    3: "MaskMode::kMultiItemScoring",
 }

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -37,6 +37,7 @@ class MaskMode(Enum):
     NON_CAUSAL = 0
     CAUSAL = 1
     CUSTOM = 2
+    MULTIITEMSCORING = 3
 
 
 class TensorLayout(Enum):

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -355,7 +355,7 @@ struct BatchPrefillPagedParams {
         prefix_len_ptr(nullptr),
         token_pos_in_items_ptr(nullptr),
         token_pos_in_items_len(0),
-        max_item_len_ptr(nullptr){}
+        max_item_len_ptr(nullptr) {}
 
   __host__ BatchPrefillPagedParams(DTypeQ* q, paged_kv_t<DTypeKV, IdType> paged_kv,
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -172,6 +172,10 @@ struct BatchPrefillRaggedParams {
   uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 
   __host__ BatchPrefillRaggedParams()
       : q(nullptr),
@@ -210,7 +214,11 @@ struct BatchPrefillRaggedParams {
         max_total_num_rows(0),
         total_num_rows(nullptr),
         padded_batch_size(0),
-        partition_kv(false) {}
+        partition_kv(false),
+        prefix_len_ptr(nullptr),
+        token_pos_in_items_ptr(nullptr),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(nullptr) {}
 
   __host__ BatchPrefillRaggedParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
                                     IdType* q_indptr, IdType* kv_indptr, IdType* maybe_mask_indptr,
@@ -257,7 +265,11 @@ struct BatchPrefillRaggedParams {
         max_total_num_rows(0),
         total_num_rows(nullptr),
         padded_batch_size(0),
-        partition_kv(false) {}
+        partition_kv(false),
+        prefix_len_ptr(nullptr),
+        token_pos_in_items_ptr(nullptr),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(nullptr) {}
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];
@@ -305,6 +317,10 @@ struct BatchPrefillPagedParams {
   uint32_t* total_num_rows;
   uint32_t padded_batch_size;
   bool partition_kv;
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 
   __host__ BatchPrefillPagedParams()
       : q(nullptr),
@@ -335,7 +351,11 @@ struct BatchPrefillPagedParams {
         max_total_num_rows(0),
         total_num_rows(nullptr),
         padded_batch_size(0),
-        partition_kv(false) {}
+        partition_kv(false),
+        prefix_len_ptr(nullptr),
+        token_pos_in_items_ptr(nullptr),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(nullptr){}
 
   __host__ BatchPrefillPagedParams(DTypeQ* q, paged_kv_t<DTypeKV, IdType> paged_kv,
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,
@@ -372,7 +392,11 @@ struct BatchPrefillPagedParams {
         max_total_num_rows(0),
         total_num_rows(nullptr),
         padded_batch_size(0),
-        partition_kv(false) {}
+        partition_kv(false),
+        prefix_len_ptr(nullptr),
+        token_pos_in_items_ptr(nullptr),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(nullptr) {}
 
   __host__ __device__ __forceinline__ uint32_t get_qo_len(uint32_t batch_idx) const {
     return q_indptr[batch_idx + 1] - q_indptr[batch_idx];

--- a/include/flashinfer/attention/hopper/default_params.cuh
+++ b/include/flashinfer/attention/hopper/default_params.cuh
@@ -82,6 +82,7 @@ struct BatchPrefillRaggedParams {
   IdType* kv_lens;
   IdType* head_indices;
   IdType* work_indptr;
+  IdType* batch_indices;
 
   struct AdditionalParams {
     float logits_soft_cap;
@@ -105,6 +106,11 @@ struct BatchPrefillRaggedParams {
   int window_left;
 
   bool causal;
+
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 };
 
 template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_>
@@ -128,6 +134,7 @@ struct BatchPrefillPagedParams {
   IdType* kv_lens;
   IdType* head_indices;
   IdType* work_indptr;
+  IdType* batch_indices;
 
   struct AdditionalParams {
     float logits_soft_cap;
@@ -151,6 +158,11 @@ struct BatchPrefillPagedParams {
   int window_left;
 
   bool causal;
+
+  uint32_t* prefix_len_ptr;
+  uint16_t* token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  uint16_t* max_item_len_ptr;
 };
 
 }  // namespace flashinfer

--- a/include/flashinfer/attention/hopper/epilogue.cuh
+++ b/include/flashinfer/attention/hopper/epilogue.cuh
@@ -153,7 +153,7 @@ struct CollectiveEpilogue {
   CUTLASS_DEVICE void store(Params const& epilogue_params, FrgTensorO const& tOrO,
                             FrgTensorLSE const& lse, SharedStorage& shared_storage,
                             TiledMma tiled_mma, int thread_idx, BlockCoord const& block_coord) {
-    auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] =
+    auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
     Tensor sO = make_tensor(make_smem_ptr(shared_storage.smem_o.data()), SmemLayoutO{});
     auto smem_tiled_copy_O = make_tiled_copy_C(SmemCopyAtomO{}, tiled_mma);
@@ -213,7 +213,7 @@ struct CollectiveEpilogue {
   template <typename BlockCoord, typename SharedStorage>
   CUTLASS_DEVICE void store_zero(Params const& epilogue_params, SharedStorage& shared_storage,
                                  int thread_idx, BlockCoord const& block_coord) {
-    auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] =
+    auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
     Tensor mO = make_tensor(make_gmem_ptr(epilogue_params.O_ptr), epilogue_params.layout_O);
     Tensor gO = get_local_tile_tensor(mO, select<0, 1>(TileShape_PDV{}), qo_head_idx, qo_indptr,

--- a/include/flashinfer/attention/hopper/mainloop.cuh
+++ b/include/flashinfer/attention/hopper/mainloop.cuh
@@ -133,9 +133,18 @@ struct CollectiveMainloop {
     Tensor mV = make_tensor(make_gmem_ptr(args.V_ptr), args.layout_V);
     TMA_V tma_load_V = make_tma_copy(GmemTiledCopyKV{}, mV, SmemLayoutV{}(_, _, _0{}),
                                      select<2, 1>(TileShape_PDV{}), _1{});  // no mcast
-    return {args.layout_Q, args.layout_K, args.layout_V,    tma_load_Q,
-            tma_load_K,    tma_load_V,    args.window_left, args.additional_params,
-            args.prefix_len_ptr, args.token_pos_in_items_ptr, args.token_pos_in_items_len, args.max_item_len_ptr};
+    return {args.layout_Q,
+            args.layout_K,
+            args.layout_V,
+            tma_load_Q,
+            tma_load_K,
+            tma_load_V,
+            args.window_left,
+            args.additional_params,
+            args.prefix_len_ptr,
+            args.token_pos_in_items_ptr,
+            args.token_pos_in_items_len,
+            args.max_item_len_ptr};
   }
 
   /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
@@ -176,7 +185,8 @@ struct CollectiveMainloop {
     Tensor mK = mainloop_params.tma_load_K.get_tma_tensor(mainloop_params.layout_K.shape());
     Tensor mV = mainloop_params.tma_load_V.get_tma_tensor(mainloop_params.layout_V.shape());
 
-    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] = block_coord;
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
+        block_coord;
 
     // Prepare the TMA loads
     Tensor gQ = get_local_tile_tensor(mQ, select<0, 2>(TileShape_QKD{}), qo_head_idx, qo_indptr,

--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -14,7 +14,7 @@
 
 namespace flashinfer {
 
-template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename WarpScheduler,
+template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, bool MULTIITEMSCORING, typename WarpScheduler,
           typename AttentionVariant, typename Params, typename MainloopPipeline,
           typename PipelineState, typename SharedStorage, typename FrgTensorO,
           typename AttentionUpdater>
@@ -26,7 +26,9 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
                             int swa_end_kv_tile_idx, int thread_idx, int work_idx, int q_tile_idx,
                             SharedStorage& shared_storage, const int32_t qo_len,
                             const int32_t kv_len, const int32_t qo_head_idx,
-                            const int32_t kv_head_idx) {
+                            const int32_t kv_head_idx,
+                            const uint32_t prefix_len, uint16_t* token_pos_in_items,
+                            const int num_kv_tiles_outside_items_window = 0, const int num_kv_tiles_prefix = 0) {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using IdType = typename Ktraits::IdType;
@@ -93,6 +95,36 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
   auto col_limit_left = [&](int qo_idx) {
     return qo_idx + kv_len - qo_len - mainloop_params.window_left;
   };
+  auto mask_multi_item_scoring = [&](decltype(tSrS)& tSrS, int i, int qo_idx, int kv_idx) {
+    const uint32_t idx_in_original_seq = qo_idx + kv_len - qo_len;
+    const bool out_of_boundary = kv_idx > idx_in_original_seq || (kv_idx >= std::min(kv_len, col_limit_right(qo_idx)));
+    const bool is_prefix = idx_in_original_seq < prefix_len;
+    uint16_t token_pos_in_items_regs = __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
+    if (out_of_boundary || is_prefix) {
+      tSrS(i) = out_of_boundary ? (AttentionUpdater::fill_value) : tSrS(i);
+    }else{
+      tSrS(i) = (kv_idx < prefix_len | (idx_in_original_seq < kv_idx + token_pos_in_items_regs)) ? tSrS(i) : (AttentionUpdater::fill_value);
+    }
+  };
+  auto mask_multi_item_scoring_assume_in_bound = [&](decltype(tSrS)& tSrS, int i, int qo_idx, int kv_idx) {
+    const uint32_t idx_in_original_seq = qo_idx + kv_len - qo_len;
+    const bool is_prefix = idx_in_original_seq < prefix_len;
+    if (is_prefix) {
+      tSrS(i) = AttentionUpdater::fill_value;
+    }else{
+      uint16_t token_pos_in_items_regs = __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
+      tSrS(i) = (kv_idx < prefix_len | (idx_in_original_seq < kv_idx + token_pos_in_items_regs)) ? tSrS(i) : (AttentionUpdater::fill_value);
+    }
+  };
+  auto kv_tile_idx_decrement = [&](int kv_tile_idx) {
+    int result = kv_tile_idx - 1;
+    if constexpr (MULTIITEMSCORING) {
+      if ((kv_tile_idx == num_kv_tiles_outside_items_window - 1) & (kv_tile_idx >= num_kv_tiles_prefix)) {
+        result = num_kv_tiles_prefix - 1;
+      }
+    }
+    return result;
+  };
   {
     Tensor cS = cute::make_identity_tensor(select<0, 1>(TileShape_QKD{}));
     Tensor tScS = threadMmaQK.partition_C(cS);
@@ -102,6 +134,9 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
       int kv_idx = get<1>(tScS(i)) + kv_tile_idx * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
+      if constexpr (MULTIITEMSCORING) {
+        mask_multi_item_scoring(tSrS, i, qo_idx, kv_idx);
+      } else
       if constexpr (!CAUSAL) {  // Just masking based on col
         if (kv_idx >= kv_len) {
           tSrS(i) = AttentionUpdater::fill_value;
@@ -123,11 +158,15 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
   Tensor tOrP = make_tensor(convert_type<DTypeKV>(tSrS).data(),
                             convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout()));
 
-  constexpr int n_masking_steps = CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0;
+  constexpr int n_masking_steps =
+      MULTIITEMSCORING
+          ? (cute::ceil_div(CTA_Q, CTA_KV) + 1)
+          : (CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0);
   // masking loops
+  // ziangl@nvidia.com: for multi item scoring, we use this loop only to mask along the diagonal
 #pragma unroll
   for (int masking_step = 0; masking_step < n_masking_steps && kv_tile_idx > swa_begin_kv_tile_idx;
-       ++masking_step, --kv_tile_idx) {
+       ++masking_step, kv_tile_idx = kv_tile_idx_decrement(kv_tile_idx)) {
     Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_QKD{}));
     consumer_wait(pipeline_k, smem_pipe_read_k);
     WarpScheduler::barrier_sync();
@@ -147,11 +186,19 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
 #pragma unroll
     for (int i = 0; i < size(tSrS); ++i) {
       int qo_idx = get<0>(tScS(i)) + q_tile_idx * CTA_Q;
-      int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
+      int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
-      if (kv_idx >= col_limit_right(qo_idx)) {
-        tSrS(i) = AttentionUpdater::fill_value;
+      if(MULTIITEMSCORING) {
+        if (masking_step == n_masking_steps - 1) {
+          mask_multi_item_scoring_assume_in_bound(tSrS, i, qo_idx, kv_idx);
+        } else {
+          mask_multi_item_scoring(tSrS, i, qo_idx, kv_idx);
+        }
+      }else{
+        if (kv_idx >= col_limit_right(qo_idx)) {
+          tSrS(i) = AttentionUpdater::fill_value;
+        }
       }
       if constexpr (LEFT_SLIDING_WINDOW) {
         if (kv_idx < col_limit_left(qo_idx)) {
@@ -170,7 +217,9 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
   }
 
 #pragma unroll 1
-  for (; kv_tile_idx > swa_end_kv_tile_idx + 1; --kv_tile_idx) {
+  for (;
+      kv_tile_idx > swa_end_kv_tile_idx + 1;
+      kv_tile_idx = kv_tile_idx_decrement(kv_tile_idx)) {
     Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_QKD{}));
     consumer_wait(pipeline_k, smem_pipe_read_k);
     WarpScheduler::barrier_sync();
@@ -189,9 +238,20 @@ CUTLASS_DEVICE void mma_f16(const Params& mainloop_params, AttentionVariant& var
 #pragma unroll
     for (int i = 0; i < size(tSrS); ++i) {
       int qo_idx = get<0>(tScS(i)) + q_tile_idx * CTA_Q;
-      int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
+      int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
+    }
+    if constexpr (MULTIITEMSCORING) {
+      // auto nums_tiles_outside_causal_diagonal = kv_tile_idx_count - cute::ceil_div(CTA_Q, CTA_KV);
+      if (kv_tile_idx >= num_kv_tiles_prefix - 1) {
+#pragma unroll
+        for (int i = 0; i < size(tSrS); ++i) {
+          int qo_idx = get<0>(tScS(i)) + q_tile_idx * CTA_Q;
+          int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
+          mask_multi_item_scoring_assume_in_bound(tSrS, i, qo_idx, kv_idx);
+        }
+      }
     }
     attention_updater.update</*init=*/false>(tSrS);
     warpgroup_wait<0>();

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -143,8 +143,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
            work_tile_info = scheduler.template get_next_work</*is_producer=*/true>(
                scheduler_params, work_tile_info)) {
         auto block_coord = work_tile_info.get_block_coord(scheduler_params);
-        auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
-            block_coord;
+        auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len,
+              batch_idx] = block_coord;
 
         if (q_tile_idx * CTA_Q >= qo_len) {
           continue;
@@ -161,7 +161,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         if constexpr (MULTIITEMSCORING) {
           auto prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
           auto max_item_len = __ldg(mainloop_params.max_item_len_ptr + batch_idx);
-          auto valid_items_window_len = std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
+          auto valid_items_window_len =
+              std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
           num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
         }
@@ -238,14 +239,16 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
       uint16_t* token_pos_in_items = nullptr;
       if constexpr (MULTIITEMSCORING) {
         prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
-        token_pos_in_items = mainloop_params.token_pos_in_items_ptr + batch_idx * mainloop_params.token_pos_in_items_len;
+        token_pos_in_items = mainloop_params.token_pos_in_items_ptr +
+                             batch_idx * mainloop_params.token_pos_in_items_len;
       }
       int num_kv_tiles_outside_items_window = 0;
       int num_kv_tiles_prefix = 0;
       if constexpr (MULTIITEMSCORING) {
         auto prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
         auto max_item_len = __ldg(mainloop_params.max_item_len_ptr + batch_idx);
-        auto valid_items_window_len = std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
+        auto valid_items_window_len =
+            std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
         num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
         num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
       }
@@ -288,8 +291,7 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
        get_gmem_layout(params.kv_len, params.num_kv_heads, KernelTraits::HEAD_DIM_VO,
                        params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.window_left, params.additional_params,
-       nullptr, nullptr, 0, nullptr});
+       params.window_left, params.additional_params, nullptr, nullptr, 0, nullptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           static_cast<DTypeO*>(params.o_ptr),
@@ -329,8 +331,7 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params,
-          bool MULTIITEMSCORING = false>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool MULTIITEMSCORING = false>
 cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
                                                                cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -338,9 +339,8 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
   using DTypeO = typename KernelTraits::DTypeO;
   using IdType = typename KernelTraits::IdType;
 
-  using CollectiveMainloop =
-      SparseCollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL,
-      MULTIITEMSCORING>;
+  using CollectiveMainloop = SparseCollectiveMainloop<typename Params::AdditionalParams,
+                                                      KernelTraits, CAUSAL, MULTIITEMSCORING>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -358,8 +358,8 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
        params.v_ptr,
        get_gmem_layout(/*nnz=*/0, params.num_kv_heads, KernelTraits::HEAD_DIM_VO, params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.kv_indices, params.window_left, params.additional_params,
-       params.prefix_len_ptr, params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
+       params.kv_indices, params.window_left, params.additional_params, params.prefix_len_ptr,
+       params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           params.o_ptr,
@@ -370,10 +370,14 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
       });
 
   typename Scheduler::Arguments scheduler_args = {
-      params.work_indptr,     params.head_indices,
-      params.qo_tile_indices, params.qo_indptr,
-      params.kv_indptr,       params.qo_lens,
-      params.kv_lens,         params.batch_indices,
+      params.work_indptr,
+      params.head_indices,
+      params.qo_tile_indices,
+      params.qo_indptr,
+      params.kv_indptr,
+      params.qo_lens,
+      params.kv_lens,
+      params.batch_indices,
       cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
       params.num_qo_heads};
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
@@ -429,8 +433,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
        get_gmem_layout(params.nnz_kv, params.num_kv_heads, KernelTraits::HEAD_DIM_VO,
                        params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.window_left, params.additional_params,
-       params.prefix_len_ptr, params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
+       params.window_left, params.additional_params, params.prefix_len_ptr,
+       params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           params.o_ptr,
@@ -442,10 +446,14 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
 
   // NOTE(Zihao): add support for kv head-major later
   typename Scheduler::Arguments scheduler_args = {
-      params.work_indptr,     params.head_indices,
-      params.qo_tile_indices, params.qo_indptr,
-      params.kv_indptr,       params.qo_lens,
-      params.kv_lens,         params.batch_indices,
+      params.work_indptr,
+      params.head_indices,
+      params.qo_tile_indices,
+      params.qo_indptr,
+      params.kv_indptr,
+      params.qo_lens,
+      params.kv_lens,
+      params.batch_indices,
       cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
       params.num_qo_heads};
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
@@ -552,8 +560,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
-          Params, MULTIITEMSCORING>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
+          params, stream);
     } else if constexpr (HEAD_DIM_VO == 128) {
       BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
           AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -562,8 +570,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
-          Params, MULTIITEMSCORING>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
+          params, stream);
     } else {
       // HEAD_DIM == 256;
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 256, need to optimize later
@@ -574,8 +582,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
-          Params, MULTIITEMSCORING>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
+          params, stream);
     }
   } else {
     return cudaErrorNotSupported;

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -36,7 +36,8 @@ namespace flashinfer {
 using namespace cute;
 
 template <typename CollectiveMainloop, typename CollectiveEpilogue, typename Ktraits,
-          bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler>
+          bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler,
+          bool MULTIITEMSCORING = false>
 __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp, 1)
     PrefillWithKVCacheKernel(CUTE_GRID_CONSTANT
                              typename CollectiveMainloop::Params const mainloop_params,
@@ -142,7 +143,7 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
            work_tile_info = scheduler.template get_next_work</*is_producer=*/true>(
                scheduler_params, work_tile_info)) {
         auto block_coord = work_tile_info.get_block_coord(scheduler_params);
-        auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] =
+        auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
             block_coord;
 
         if (q_tile_idx * CTA_Q >= qo_len) {
@@ -155,9 +156,25 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           scheduler.broadcast_next_work(work_tile_info);
           continue;
         }
-        collective_mainloop.load<LEFT_SLIDING_WINDOW>(
-            mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
-            shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx);
+        int num_kv_tiles_outside_items_window = 0;
+        int num_kv_tiles_prefix = 0;
+        if constexpr (MULTIITEMSCORING) {
+          auto prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
+          auto max_item_len = __ldg(mainloop_params.max_item_len_ptr + batch_idx);
+          auto valid_items_window_len = std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
+          num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
+          num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
+        }
+        if constexpr (MULTIITEMSCORING) {
+          collective_mainloop.load<LEFT_SLIDING_WINDOW>(
+              mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
+              shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx,
+              num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
+        } else {
+          collective_mainloop.load<LEFT_SLIDING_WINDOW>(
+              mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
+              shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx);
+        }
         ++work_idx;
       }
       collective_mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v);
@@ -190,7 +207,7 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
       Tensor tOrO = partition_fragment_C(tiled_mma_pv, select<0, 1>(TileShape_PDV{}));
 
       auto block_coord = work_tile_info.get_block_coord(scheduler_params);
-      auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] =
+      auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
           block_coord;
 
       AttentionVariant variant(mainloop_params, block_coord);
@@ -217,12 +234,28 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
                                                                      q_tile_idx, qo_len, kv_len);
       }
 
-      mma_f16<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL,
+      uint32_t prefix_len = 0;
+      uint16_t* token_pos_in_items = nullptr;
+      if constexpr (MULTIITEMSCORING) {
+        prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
+        token_pos_in_items = mainloop_params.token_pos_in_items_ptr + batch_idx * mainloop_params.token_pos_in_items_len;
+      }
+      int num_kv_tiles_outside_items_window = 0;
+      int num_kv_tiles_prefix = 0;
+      if constexpr (MULTIITEMSCORING) {
+        auto prefix_len = __ldg(mainloop_params.prefix_len_ptr + batch_idx);
+        auto max_item_len = __ldg(mainloop_params.max_item_len_ptr + batch_idx);
+        auto valid_items_window_len = std::max(0, (q_tile_idx + 1) * CTA_Q + kv_len - qo_len - max_item_len);
+        num_kv_tiles_outside_items_window = cute::ceil_div(valid_items_window_len, CTA_KV);
+        num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
+      }
+      mma_f16<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL, MULTIITEMSCORING,
               CollectiveMainloop::WarpScheduler>(
           mainloop_params, variant, pipeline_k, pipeline_v, smem_pipe_read_k, smem_pipe_read_v,
           tOrO, attention_updater, num_kv_tiles, swa_begin_kv_tile_idx, swa_end_kv_tile_idx,
           threadIdx.x - NUM_COPY_THREADS, work_idx, q_tile_idx, shared_storage, qo_len, kv_len,
-          qo_head_idx, kv_head_idx);
+          qo_head_idx, kv_head_idx, prefix_len, token_pos_in_items,
+          num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
                                 tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
 
@@ -255,7 +288,8 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
        get_gmem_layout(params.kv_len, params.num_kv_heads, KernelTraits::HEAD_DIM_VO,
                        params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.window_left, params.additional_params});
+       params.window_left, params.additional_params,
+       nullptr, nullptr, 0, nullptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           static_cast<DTypeO*>(params.o_ptr),
@@ -295,7 +329,8 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params,
+          bool MULTIITEMSCORING = false>
 cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
                                                                cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -304,7 +339,8 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
   using IdType = typename KernelTraits::IdType;
 
   using CollectiveMainloop =
-      SparseCollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>;
+      SparseCollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL,
+      MULTIITEMSCORING>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -322,7 +358,8 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
        params.v_ptr,
        get_gmem_layout(/*nnz=*/0, params.num_kv_heads, KernelTraits::HEAD_DIM_VO, params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.kv_indices, params.window_left, params.additional_params});
+       params.kv_indices, params.window_left, params.additional_params,
+       params.prefix_len_ptr, params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           params.o_ptr,
@@ -336,14 +373,15 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
       params.work_indptr,     params.head_indices,
       params.qo_tile_indices, params.qo_indptr,
       params.kv_indptr,       params.qo_lens,
-      params.kv_lens,         cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
+      params.kv_lens,         params.batch_indices,
+      cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
       params.num_qo_heads};
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
   // Get the ptr to kernel function.
   auto kernel =
       (void*)PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler>;
+                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler, MULTIITEMSCORING>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -391,7 +429,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
        get_gmem_layout(params.nnz_kv, params.num_kv_heads, KernelTraits::HEAD_DIM_VO,
                        params.v_stride_n,
                        params.v_stride_h),  // layout_V
-       params.window_left, params.additional_params});
+       params.window_left, params.additional_params,
+       params.prefix_len_ptr, params.token_pos_in_items_ptr, params.token_pos_in_items_len, params.max_item_len_ptr});
   typename CollectiveEpilogue::Params epilogue_params =
       CollectiveEpilogue::to_underlying_arguments({
           params.o_ptr,
@@ -406,7 +445,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
       params.work_indptr,     params.head_indices,
       params.qo_tile_indices, params.qo_indptr,
       params.kv_indptr,       params.qo_lens,
-      params.kv_lens,         cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
+      params.kv_lens,         params.batch_indices,
+      cutlass::FastDivmod(params.num_qo_heads / params.num_kv_heads),
       params.num_qo_heads};
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
@@ -501,6 +541,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
     return cudaErrorNotSupported;  // Not supported yet.
   }
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
+  constexpr bool MULTIITEMSCORING = MASK_MODE == MaskMode::kMultiItemScoring;
   if constexpr (HEAD_DIM_QK == HEAD_DIM_VO) {
     if constexpr (HEAD_DIM_VO == 64) {
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 64, need to optimize later
@@ -511,7 +552,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
+          Params, MULTIITEMSCORING>(params, stream);
     } else if constexpr (HEAD_DIM_VO == 128) {
       BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
           AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -520,7 +562,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
+          Params, MULTIITEMSCORING>(params, stream);
     } else {
       // HEAD_DIM == 256;
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 256, need to optimize later
@@ -531,7 +574,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, cudaStream_t 
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS,
+          Params, MULTIITEMSCORING>(params, stream);
     }
   } else {
     return cudaErrorNotSupported;

--- a/include/flashinfer/attention/hopper/sparse_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/sparse_mainloop.cuh
@@ -33,7 +33,8 @@ namespace flashinfer {
 
 using namespace cute;
 
-template <typename AdditionalParams, typename Ktraits, bool CAUSAL>
+template <typename AdditionalParams, typename Ktraits, bool CAUSAL,
+          bool MULTIITEMSCORING = false>
 struct SparseCollectiveMainloop {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
@@ -108,6 +109,10 @@ struct SparseCollectiveMainloop {
     IdType const* kv_indices;
     int window_left;
     AdditionalParams additional_params;
+    uint32_t* prefix_len_ptr;
+    uint16_t* token_pos_in_items_ptr;
+    uint32_t token_pos_in_items_len;
+    uint16_t* max_item_len_ptr;
   };
 
   // Device side kernel params
@@ -121,6 +126,10 @@ struct SparseCollectiveMainloop {
     IdType* kv_indices;
     int window_left;
     AdditionalParams additional_params;
+    uint32_t* prefix_len_ptr;
+    uint16_t* token_pos_in_items_ptr;
+    uint32_t token_pos_in_items_len;
+    uint16_t* max_item_len_ptr;
   };
 
   static Params to_underlying_arguments(Arguments const& args) {
@@ -135,7 +144,11 @@ struct SparseCollectiveMainloop {
             const_cast<DTypeKV*>(args.V_ptr),
             const_cast<IdType*>(args.kv_indices),
             args.window_left,
-            args.additional_params};
+            args.additional_params,
+            args.prefix_len_ptr,
+            args.token_pos_in_items_ptr,
+            args.token_pos_in_items_len,
+            args.max_item_len_ptr};
   }
 
   CUTLASS_DEVICE
@@ -153,6 +166,10 @@ struct SparseCollectiveMainloop {
       num_kv_tiles = std::min(num_kv_tiles,
                               cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
     }
+    if constexpr (MULTIITEMSCORING) {
+      num_kv_tiles = std::min(num_kv_tiles,
+                              cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
+    }
 
     return num_kv_tiles;
   }
@@ -164,7 +181,8 @@ struct SparseCollectiveMainloop {
                            PipelineState& smem_pipe_write_v, SharedStorage& shared_storage,
                            Scheduler& scheduler, typename Scheduler::Params const& scheduler_params,
                            typename Scheduler::WorkTileInfo& work_tile_info,
-                           BlockCoord const& block_coord, int work_idx) {
+                           BlockCoord const& block_coord, int work_idx,
+                           const int num_kv_tiles_outside_items_window = 0, const int num_kv_tiles_prefix = 0) {
     int thread_idx = threadIdx.x;
     int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (thread_idx / 32) % 4, 0);
     Tensor sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.data()), SmemLayoutQ{});
@@ -173,7 +191,7 @@ struct SparseCollectiveMainloop {
 
     Tensor mQ = mainloop_params.tma_load_Q.get_tma_tensor(mainloop_params.layout_Q.shape());
 
-    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len] = block_coord;
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] = block_coord;
 
     // Prepare the TMA loads
     Tensor gQ = get_local_tile_tensor(mQ, select<0, 2>(TileShape_QKD{}), qo_head_idx, qo_indptr,
@@ -235,6 +253,15 @@ struct SparseCollectiveMainloop {
       auto s_coords = tVcVGroup(_0{}, coords);
       return elem_less(get<0>(s_coords), valid_last_kv_tile_size);
     };
+    auto kv_tile_idx_decrement = [&](int kv_tile_idx) {
+      int result = kv_tile_idx - 1;
+      if constexpr (MULTIITEMSCORING) {
+        if ((kv_tile_idx == num_kv_tiles_outside_items_window - 1) & (kv_tile_idx >= num_kv_tiles_prefix)) {
+          result = num_kv_tiles_prefix - 1;
+        }
+      }
+      return result;
+    };
 
     // load last k-tile
     {
@@ -278,7 +305,7 @@ struct SparseCollectiveMainloop {
     } else {
       // load second last k-tile and last v-tile
       pipeline_k.producer_acquire(smem_pipe_write_k);
-      Tensor tKgKi = tKgK(_, _, _, kv_tile_idx - 1);            // (CPY, CPY_KV, CPY_D)
+      Tensor tKgKi = tKgK(_, _, _, kv_tile_idx_decrement(kv_tile_idx));            // (CPY, CPY_KV, CPY_D)
       Tensor tKsKi = tKsK(_, _, _, smem_pipe_write_k.index());  // (CPY, CPY_KV, CPY_D)
       copy(gmem_tiled_copy_k, tKgKi, tKsKi);
 
@@ -292,15 +319,18 @@ struct SparseCollectiveMainloop {
       copy_if(gmem_tiled_copy_v, v_predicate_fn, tVgViGroup, tVsViGroup);
 
       pipeline_v.producer_commit(smem_pipe_write_v, cutlass::arch::cpasync_barrier_arrive);
-      --kv_tile_idx;
+      kv_tile_idx = kv_tile_idx_decrement(kv_tile_idx);
       ++smem_pipe_write_v;
 
       // load remaining k/v tiles
 #pragma unroll 2
-      for (; kv_tile_idx > swa_begin_kv_tile_idx; --kv_tile_idx) {
+      for (;
+          kv_tile_idx > swa_begin_kv_tile_idx;
+          kv_tile_idx = kv_tile_idx_decrement(kv_tile_idx)
+      ) {
         pipeline_k.producer_acquire(smem_pipe_write_k);
 
-        Tensor tKgKi = tKgK(_, _, _, kv_tile_idx - 1);            // (CPY, CPY_KV, CPY_D)
+        Tensor tKgKi = tKgK(_, _, _, kv_tile_idx_decrement(kv_tile_idx));            // (CPY, CPY_KV, CPY_D)
         Tensor tKsKi = tKsK(_, _, _, smem_pipe_write_k.index());  // (CPY, CPY_KV, CPY_D)
         copy(gmem_tiled_copy_k, tKgKi, tKsKi);
 

--- a/include/flashinfer/attention/mask.cuh
+++ b/include/flashinfer/attention/mask.cuh
@@ -22,6 +22,7 @@ enum class MaskMode {
   kNone = 0U,    // No mask
   kCausal = 1U,  // Causal mask
   kCustom = 2U,  // Custom mask
+  kMultiItemScoring = 3U,
 };
 
 }  // namespace flashinfer

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -786,6 +786,74 @@ __device__ __forceinline__ void logits_mask(
   }
 }
 
+template <typename KTraits, typename Params>
+__device__ __forceinline__ void logits_mask_customized(
+  const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
+    const uint32_t qo_packed_idx_base, const uint32_t kv_idx_base, const uint32_t qo_len,
+    const uint32_t kv_len, const uint32_t window_left, const uint32_t chunk_end, const uint_fastdiv group_size,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    // new arguments for compact description of mask
+    const uint32_t prefix_len, uint16_t* token_pos_in_items) {
+  const uint32_t lane_idx = threadIdx.x, kv_head_idx = blockIdx.z;
+  constexpr uint32_t NUM_MMA_Q = KTraits::NUM_MMA_Q;
+  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  using DTypeQKAccum = typename KTraits::DTypeQKAccum;
+  uint32_t q[NUM_MMA_Q][2], r[NUM_MMA_Q][2];
+
+#pragma unroll
+  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+    for (uint32_t j = 0; j < 2; ++j) {
+      group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / 4 + 8 * j, q[mma_q][j],
+                        r[mma_q][j]);
+    }
+  }
+  // prefetching global memory to registers
+  uint16_t token_pos_in_items_regs[NUM_MMA_Q][(4 / 2)];
+#pragma unroll
+  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+    for (uint32_t eff_reg_id = 0; eff_reg_id < (4 / 2); ++eff_reg_id) {
+      const uint32_t q_idx = q[mma_q][eff_reg_id];
+      // use __ldca to hint compiler to cache in L1 for further reuse by other tiles
+      const int idx_in_original_seq = q_idx + kv_len - qo_len;
+      if (idx_in_original_seq >= prefix_len & idx_in_original_seq < kv_len) {
+        token_pos_in_items_regs[mma_q][eff_reg_id] = __ldca(token_pos_in_items + idx_in_original_seq - prefix_len);
+      }
+    }
+  }
+
+
+#pragma unroll
+  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+      for (uint32_t reg_id = 0; reg_id < 8; ++reg_id) {
+        const uint32_t q_idx = q[mma_q][(reg_id % 4) / 2], kv_idx = kv_idx_base + mma_kv * 16 +
+                                                                    2 * (lane_idx % 4) +
+                                                                    8 * (reg_id / 4) + reg_id % 2;
+        const uint32_t qo_head_idx = kv_head_idx * group_size + r[mma_q][(reg_id % 4) / 2];
+        const uint32_t idx_in_original_seq = q_idx + kv_len - qo_len;
+        const bool out_of_boundary =
+                    kv_idx > idx_in_original_seq || (kv_idx >= chunk_end) ||
+                    kv_idx + window_left < idx_in_original_seq;
+        const bool is_prefix = idx_in_original_seq < prefix_len;
+        if (out_of_boundary || is_prefix) {
+          s_frag[mma_q][mma_kv][reg_id] = out_of_boundary ? (KTraits::MaskFillValue) : s_frag[mma_q][mma_kv][reg_id];
+        } else {
+          s_frag[mma_q][mma_kv][reg_id] =
+            (kv_idx < prefix_len |
+              (idx_in_original_seq < kv_idx + token_pos_in_items_regs[mma_q][((reg_id % 4) / 2)])
+            )
+          ? s_frag[mma_q][mma_kv][reg_id]
+          : (KTraits::MaskFillValue);
+        }
+      }
+    }
+  }
+}
+
 template <typename KTraits>
 __device__ __forceinline__ void update_mdo_states(
     typename KTraits::AttentionVariant variant,
@@ -1980,6 +2048,11 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     const int32_t maybe_window_left = params.window_left;
     const uint_fastdiv& group_size = params.group_size;
 
+    uint32_t* prefix_len_ptr = params.prefix_len_ptr;
+    uint16_t* token_pos_in_items_ptr = params.token_pos_in_items_ptr;
+    const uint32_t token_pos_in_items_len =  params.token_pos_in_items_len;
+    uint16_t* max_item_len_ptr = params.max_item_len_ptr;
+
     static_assert(sizeof(DTypeQ) == 2);
     auto block = cg::this_thread_block();
     const uint32_t kv_chunk_size = *(params.kv_chunk_size_ptr);
@@ -2093,13 +2166,41 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                    chunk_size, tid);
     cp_async::commit_group();
 
-    const uint32_t num_iterations = ceil_div(
+    uint32_t num_iterations;
+    uint32_t num_iterations_mask;
+    uint32_t num_iterations_full = 0;
+
+    if constexpr (MASK_MODE != MaskMode::kMultiItemScoring) {
+      num_iterations = ceil_div(
         (MASK_MODE == MaskMode::kCausal
-             ? min(chunk_size, sub_if_greater_or_zero(
-                                   kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
-                                   chunk_start))
+             ? min(chunk_size,
+                   sub_if_greater_or_zero(
+                       kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
+                       chunk_start))
              : chunk_size),
         CTA_TILE_KV);
+    } else {
+      num_iterations = ceil_div(
+        min(
+            min(chunk_size,
+                sub_if_greater_or_zero(
+                    kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
+                    chunk_start))
+            , sub_if_greater_or_zero(__ldg(prefix_len_ptr + request_idx), chunk_start)
+        ),
+        CTA_TILE_KV);
+      num_iterations_mask =
+          max(min(chunk_size, sub_if_greater_or_zero(
+                          sub_if_greater_or_zero(kv_len - qo_len + (qo_tile_idx * CTA_TILE_Q) / group_size,
+                                                __ldg(max_item_len_ptr + request_idx)),
+                          chunk_start)) / (CTA_TILE_KV), num_iterations);
+
+      num_iterations_full = max(num_iterations_mask, ceil_div(
+          min(chunk_size, sub_if_greater_or_zero(
+                          kv_len - qo_len + ((qo_tile_idx + 1) * CTA_TILE_Q) / group_size,
+                          chunk_start)),
+          CTA_TILE_KV));
+    }
 
     const uint32_t window_iteration =
         ceil_div(sub_if_greater_or_zero(kv_len + (qo_tile_idx + 1) * CTA_TILE_Q / group_size,
@@ -2114,9 +2215,19 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
              : chunk_size) /
         CTA_TILE_KV;
 
+    const uint32_t unified_num_iterations = (MASK_MODE == MaskMode::kMultiItemScoring) ? num_iterations_full : num_iterations;
 #pragma unroll 1
-    for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-      packed_page_iter_base += CTA_TILE_KV;
+    for (uint32_t iter = 0;
+         iter < unified_num_iterations;
+         iter =
+            (MASK_MODE == MaskMode::kMultiItemScoring)
+            ? ((iter + 1 == num_iterations) ? num_iterations_mask : (iter + 1))
+            : (iter + 1)) {
+      const uint32_t prefetch_skip_step =
+          (MASK_MODE == MaskMode::kMultiItemScoring)
+          ? ((iter + 1 == num_iterations) ? (num_iterations_mask - num_iterations) : 0)
+          : 0;
+      packed_page_iter_base += (1 + prefetch_skip_step) * CTA_TILE_KV;
 #pragma unroll
       for (uint32_t i = 0;
            i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
@@ -2149,11 +2260,35 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           qo_len, kv_len, group_size, s_frag, tid, kv_head_idx);
 
       // apply mask
-      if (MASK_MODE == MaskMode::kCustom || (iter >= mask_iteration || iter < window_iteration)) {
+      if (MASK_MODE == MaskMode::kCustom) {
         logits_mask<KTraits>(
-            params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16,
-            qo_len, kv_len, chunk_end, group_size, s_frag, tid, kv_head_idx);
+              params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+              chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) * NUM_MMA_KV * 16,
+              qo_len, kv_len, chunk_end, group_size, s_frag);
+      } else {
+        if constexpr (MASK_MODE != MaskMode::kMultiItemScoring) {
+          if (iter >= mask_iteration || iter < window_iteration) {
+            logits_mask<KTraits>(
+              params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+              chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) * NUM_MMA_KV * 16,
+              qo_len, kv_len, chunk_end, group_size, s_frag);
+          }
+        } else {
+          if (iter + 1 >= num_iterations) {
+            logits_mask_customized<KTraits>(
+              params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+              chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) * NUM_MMA_KV * 16,
+              qo_len, kv_len, window_left, chunk_end, group_size, s_frag,
+              __ldg(prefix_len_ptr + request_idx), token_pos_in_items_ptr + request_idx * token_pos_in_items_len);
+          } else {
+            if (iter >= mask_iteration || iter < window_iteration) {
+              logits_mask<KTraits>(
+                params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
+                chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>()) * NUM_MMA_KV * 16,
+                qo_len, kv_len, chunk_end, group_size, s_frag);
+            }
+          }
+        }
       }
 
       // compute m,d states in online softmax

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -602,6 +602,10 @@ struct PrefillPlanInfo {
   int64_t v_offset;
   int64_t s_offset;
   int64_t block_valid_mask_offset;
+  int64_t prefix_len_ptr;
+  int64_t token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  int64_t max_item_len_ptr;
   bool enable_cuda_graph;
   bool split_kv;
 
@@ -619,6 +623,10 @@ struct PrefillPlanInfo {
         v_offset(0),
         s_offset(0),
         block_valid_mask_offset(0),
+        prefix_len_ptr(0),
+        token_pos_in_items_ptr(0),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(0),
         enable_cuda_graph(false),
         split_kv(false) {}
 
@@ -637,15 +645,19 @@ struct PrefillPlanInfo {
             v_offset,
             s_offset,
             block_valid_mask_offset,
+            prefix_len_ptr,
+            token_pos_in_items_ptr,
+            token_pos_in_items_len,
+            max_item_len_ptr,
             enable_cuda_graph,
             split_kv};
   }
 
   // From std::vector<int64_t> to PrefillPlanInfo
   void FromVector(const std::vector<int64_t>& vec) {
-    if (vec.size() != 15) {
+    if (vec.size() != 19) {
       std::ostringstream err_msg;
-      err_msg << "PrefillPlanInfo::FromVector: vec.size() should be 15, but got " << vec.size();
+      err_msg << "PrefillPlanInfo::FromVector: vec.size() should be 19, but got " << vec.size();
       FLASHINFER_ERROR(err_msg.str());
     }
     padded_batch_size = vec[0];
@@ -661,8 +673,12 @@ struct PrefillPlanInfo {
     v_offset = vec[10];
     s_offset = vec[11];
     block_valid_mask_offset = vec[12];
-    enable_cuda_graph = vec[13];
-    split_kv = vec[14];
+    prefix_len_ptr = vec[13];
+    token_pos_in_items_ptr = vec[14];
+    token_pos_in_items_len = vec[15];
+    max_item_len_ptr = vec[16];
+    enable_cuda_graph = vec[17];
+    split_kv = vec[18];
   }
 };
 
@@ -673,8 +689,9 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
                                IdType* qo_indptr_h, IdType* kv_indptr_h, uint32_t total_num_rows,
                                uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
                                uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
-                               bool enable_cuda_graph, uint32_t sizeof_dtype_o,
-                               cudaStream_t stream) {
+                               bool enable_cuda_graph, uint32_t sizeof_dtype_o, cudaStream_t stream,
+                               void* prefix_len_ptr, void* token_pos_in_items_ptr,
+                               uint32_t token_pos_in_items_len, void* max_item_len_ptr) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -703,6 +720,26 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   plan_info.enable_cuda_graph = enable_cuda_graph;
   plan_info.padded_batch_size = padded_batch_size;
   plan_info.split_kv = split_kv;
+
+  if(prefix_len_ptr == nullptr){
+    plan_info.prefix_len_ptr = 0;
+  }else{
+    plan_info.prefix_len_ptr = reinterpret_cast<int64_t>(prefix_len_ptr);
+  }
+
+  if(token_pos_in_items_ptr == nullptr){
+    plan_info.token_pos_in_items_ptr = 0;
+  }else{
+    plan_info.token_pos_in_items_ptr = reinterpret_cast<int64_t>(token_pos_in_items_ptr);
+  }
+
+  plan_info.token_pos_in_items_len = token_pos_in_items_len;
+
+  if(max_item_len_ptr == nullptr){
+    plan_info.max_item_len_ptr = 0;
+  }else{
+    plan_info.max_item_len_ptr = reinterpret_cast<int64_t>(max_item_len_ptr);
+  }
 
   AlignedAllocator int_allocator(int_buffer, int_workspace_size_in_bytes);
   plan_info.request_indices_offset = int_allocator.aligned_alloc_offset(
@@ -789,6 +826,11 @@ struct PrefillPlanSM90Info {
   int64_t kv_len_offset;
   int64_t head_indices_offset;
   int64_t work_indptr_offset;
+  int64_t batch_indices_offset;
+  int64_t prefix_len_ptr;
+  int64_t token_pos_in_items_ptr;
+  uint32_t token_pos_in_items_len;
+  int64_t max_item_len_ptr;
   bool same_schedule_for_all_heads;
 
   PrefillPlanSM90Info()
@@ -799,21 +841,35 @@ struct PrefillPlanSM90Info {
         kv_len_offset(0),
         head_indices_offset(0),
         work_indptr_offset(0),
+        prefix_len_ptr(0),
+        batch_indices_offset(0),
+        token_pos_in_items_ptr(0),
+        token_pos_in_items_len(0),
+        max_item_len_ptr(0),
         same_schedule_for_all_heads(false) {}
 
   // convert PrefillPlanSM90Info to std::vector<int64_t>
   std::vector<int64_t> ToVector() const {
-    return {qo_tile_indices_offset, qo_indptr_offset,
-            kv_indptr_offset,       qo_len_offset,
-            kv_len_offset,          head_indices_offset,
-            work_indptr_offset,     same_schedule_for_all_heads};
+    return {qo_tile_indices_offset,
+            qo_indptr_offset,
+            kv_indptr_offset,
+            qo_len_offset,
+            kv_len_offset,
+            head_indices_offset,
+            work_indptr_offset,
+            batch_indices_offset,
+            prefix_len_ptr,
+            token_pos_in_items_ptr,
+            token_pos_in_items_len,
+            max_item_len_ptr,
+            same_schedule_for_all_heads};
   }
 
   // From std::vector<int64_t> to PrefillPlanSM90Info
   void FromVector(const std::vector<int64_t>& vec) {
-    if (vec.size() != 8) {
+    if (vec.size() != 13) {
       std::ostringstream err_msg;
-      err_msg << "PrefillPlanSM90Info::FromVector: vec.size() should be 8, but got " << vec.size();
+      err_msg << "PrefillPlanSM90Info::FromVector: vec.size() should be 13, but got " << vec.size();
       FLASHINFER_ERROR(err_msg.str());
     }
     qo_tile_indices_offset = vec[0];
@@ -823,7 +879,12 @@ struct PrefillPlanSM90Info {
     kv_len_offset = vec[4];
     head_indices_offset = vec[5];
     work_indptr_offset = vec[6];
-    same_schedule_for_all_heads = vec[7];
+    batch_indices_offset = vec[7];
+    prefix_len_ptr = vec[8];
+    token_pos_in_items_ptr = vec[9];
+    token_pos_in_items_len = vec[10];
+    max_item_len_ptr = vec[11];
+    same_schedule_for_all_heads = vec[12];
   }
 };
 
@@ -834,7 +895,9 @@ inline cudaError_t PrefillSM90Plan(
     PrefillPlanSM90Info& plan_info, IdType* qo_indptr_h, IdType* kv_indptr_h, IdType* kv_len_arr_h,
     uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
     uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size, bool causal,
-    bool enable_cuda_graph, uint32_t sizeof_dtype_o, cudaStream_t stream) {
+    bool enable_cuda_graph, uint32_t sizeof_dtype_o, cudaStream_t stream,
+    void* prefix_len_ptr, void* token_pos_in_items_ptr, uint32_t token_pos_in_items_len, void* max_item_len_ptr
+    ) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -879,7 +942,9 @@ inline cudaError_t PrefillSM90Plan(
       cta_kv_indptr(num_sm90_ctas, std::vector<IdType>()),
       cta_qo_len(num_sm90_ctas, std::vector<IdType>()),
       cta_kv_len(num_sm90_ctas, std::vector<IdType>()),
-      cta_head_indices(num_sm90_ctas, std::vector<IdType>());
+      cta_head_indices(num_sm90_ctas, std::vector<IdType>()),
+      cta_batch_indices(num_sm90_ctas, std::vector<IdType>());
+
 
   int max_num_works_per_head = ceil_div(total_num_rows, cta_tile_q) + batch_size - 1;
   plan_info.same_schedule_for_all_heads = max_num_works_per_head > 4096;
@@ -903,6 +968,7 @@ inline cudaError_t PrefillSM90Plan(
         cta_kv_indptr[cta_idx].push_back(kv_indptr_h[i]);
         cta_kv_len[cta_idx].push_back(kv_len);
         cta_head_indices[cta_idx].push_back(qo_head_idx);
+        cta_batch_indices[cta_idx].push_back(i);
       }
     }
   }
@@ -918,6 +984,7 @@ inline cudaError_t PrefillSM90Plan(
   auto qo_len_vec = flatten(cta_qo_len, total_num_works);
   auto kv_len_vec = flatten(cta_kv_len, total_num_works);
   auto head_indices_vec = flatten(cta_head_indices, total_num_works);
+  auto batch_indices_vec = flatten(cta_batch_indices, total_num_works);
 
   AlignedAllocator int_allocator(int_buffer, int_workspace_size_in_bytes);
   int max_total_num_works;
@@ -944,6 +1011,28 @@ inline cudaError_t PrefillSM90Plan(
       sizeof(IdType) * max_total_num_works, 16, "batch_prefill_sm90_head_indices");
   plan_info.work_indptr_offset = int_allocator.aligned_alloc_offset(
       sizeof(IdType) * (num_sm90_ctas + 1), 16, "batch_prefill_sm90_work_indptr");
+  plan_info.batch_indices_offset = int_allocator.aligned_alloc_offset(
+      sizeof(IdType) * max_total_num_works, 16, "batch_prefill_sm90_batch_indices");
+
+  if(prefix_len_ptr == nullptr){
+    plan_info.prefix_len_ptr = 0;
+  }else{
+    plan_info.prefix_len_ptr = reinterpret_cast<int64_t>(prefix_len_ptr);
+  }
+
+  if(token_pos_in_items_ptr == nullptr){
+    plan_info.token_pos_in_items_ptr = 0;
+  }else{
+    plan_info.token_pos_in_items_ptr = reinterpret_cast<int64_t>(token_pos_in_items_ptr);
+  }
+
+  plan_info.token_pos_in_items_len = token_pos_in_items_len;
+
+  if(max_item_len_ptr == nullptr){
+    plan_info.max_item_len_ptr = 0;
+  }else{
+    plan_info.max_item_len_ptr = reinterpret_cast<int64_t>(max_item_len_ptr);
+  }
 
   IdType* qo_tile_indices_h =
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.qo_tile_indices_offset);
@@ -957,6 +1046,8 @@ inline cudaError_t PrefillSM90Plan(
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.head_indices_offset);
   IdType* work_indptr_h =
       GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.work_indptr_offset);
+  IdType* batch_indices_h =
+      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.batch_indices_offset);
 
   std::copy(qo_tile_indices_vec.begin(), qo_tile_indices_vec.end(), qo_tile_indices_h);
   std::copy(qo_indptr_vec.begin(), qo_indptr_vec.end(), qo_offset_h);
@@ -965,6 +1056,7 @@ inline cudaError_t PrefillSM90Plan(
   std::copy(kv_len_vec.begin(), kv_len_vec.end(), kv_len_h);
   std::copy(head_indices_vec.begin(), head_indices_vec.end(), head_indices_h);
   std::copy(work_indptr_vec.begin(), work_indptr_vec.end(), work_indptr_h);
+  std::copy(batch_indices_vec.begin(), batch_indices_vec.end(), batch_indices_h);
 
   size_t num_bytes_to_copy = int_allocator.num_allocated_bytes();
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -721,23 +721,23 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   plan_info.padded_batch_size = padded_batch_size;
   plan_info.split_kv = split_kv;
 
-  if(prefix_len_ptr == nullptr){
+  if (prefix_len_ptr == nullptr) {
     plan_info.prefix_len_ptr = 0;
-  }else{
+  } else {
     plan_info.prefix_len_ptr = reinterpret_cast<int64_t>(prefix_len_ptr);
   }
 
-  if(token_pos_in_items_ptr == nullptr){
+  if (token_pos_in_items_ptr == nullptr) {
     plan_info.token_pos_in_items_ptr = 0;
-  }else{
+  } else {
     plan_info.token_pos_in_items_ptr = reinterpret_cast<int64_t>(token_pos_in_items_ptr);
   }
 
   plan_info.token_pos_in_items_len = token_pos_in_items_len;
 
-  if(max_item_len_ptr == nullptr){
+  if (max_item_len_ptr == nullptr) {
     plan_info.max_item_len_ptr = 0;
-  }else{
+  } else {
     plan_info.max_item_len_ptr = reinterpret_cast<int64_t>(max_item_len_ptr);
   }
 
@@ -895,9 +895,8 @@ inline cudaError_t PrefillSM90Plan(
     PrefillPlanSM90Info& plan_info, IdType* qo_indptr_h, IdType* kv_indptr_h, IdType* kv_len_arr_h,
     uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
     uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size, bool causal,
-    bool enable_cuda_graph, uint32_t sizeof_dtype_o, cudaStream_t stream,
-    void* prefix_len_ptr, void* token_pos_in_items_ptr, uint32_t token_pos_in_items_len, void* max_item_len_ptr
-    ) {
+    bool enable_cuda_graph, uint32_t sizeof_dtype_o, cudaStream_t stream, void* prefix_len_ptr,
+    void* token_pos_in_items_ptr, uint32_t token_pos_in_items_len, void* max_item_len_ptr) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -944,7 +943,6 @@ inline cudaError_t PrefillSM90Plan(
       cta_kv_len(num_sm90_ctas, std::vector<IdType>()),
       cta_head_indices(num_sm90_ctas, std::vector<IdType>()),
       cta_batch_indices(num_sm90_ctas, std::vector<IdType>());
-
 
   int max_num_works_per_head = ceil_div(total_num_rows, cta_tile_q) + batch_size - 1;
   plan_info.same_schedule_for_all_heads = max_num_works_per_head > 4096;
@@ -1014,23 +1012,23 @@ inline cudaError_t PrefillSM90Plan(
   plan_info.batch_indices_offset = int_allocator.aligned_alloc_offset(
       sizeof(IdType) * max_total_num_works, 16, "batch_prefill_sm90_batch_indices");
 
-  if(prefix_len_ptr == nullptr){
+  if (prefix_len_ptr == nullptr) {
     plan_info.prefix_len_ptr = 0;
-  }else{
+  } else {
     plan_info.prefix_len_ptr = reinterpret_cast<int64_t>(prefix_len_ptr);
   }
 
-  if(token_pos_in_items_ptr == nullptr){
+  if (token_pos_in_items_ptr == nullptr) {
     plan_info.token_pos_in_items_ptr = 0;
-  }else{
+  } else {
     plan_info.token_pos_in_items_ptr = reinterpret_cast<int64_t>(token_pos_in_items_ptr);
   }
 
   plan_info.token_pos_in_items_len = token_pos_in_items_len;
 
-  if(max_item_len_ptr == nullptr){
+  if (max_item_len_ptr == nullptr) {
     plan_info.max_item_len_ptr = 0;
-  }else{
+  } else {
     plan_info.max_item_len_ptr = reinterpret_cast<int64_t>(max_item_len_ptr);
   }
 

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -159,6 +159,11 @@
       __VA_ARGS__                                             \
       break;                                                  \
     }                                                         \
+    case MaskMode::kMultiItemScoring: {                       \
+      constexpr MaskMode MASK_MODE = MaskMode::kMultiItemScoring; \
+      __VA_ARGS__                                             \
+      break;                                                  \
+    }                                                         \
     default: {                                                \
       std::ostringstream err_msg;                             \
       err_msg << "Unsupported mask_mode: " << int(mask_mode); \

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -142,33 +142,33 @@
     FLASHINFER_ERROR(err_msg.str());                         \
   }
 
-#define DISPATCH_MASK_MODE(mask_mode, MASK_MODE, ...)         \
-  switch (mask_mode) {                                        \
-    case MaskMode::kNone: {                                   \
-      constexpr MaskMode MASK_MODE = MaskMode::kNone;         \
-      __VA_ARGS__                                             \
-      break;                                                  \
-    }                                                         \
-    case MaskMode::kCausal: {                                 \
-      constexpr MaskMode MASK_MODE = MaskMode::kCausal;       \
-      __VA_ARGS__                                             \
-      break;                                                  \
-    }                                                         \
-    case MaskMode::kCustom: {                                 \
-      constexpr MaskMode MASK_MODE = MaskMode::kCustom;       \
-      __VA_ARGS__                                             \
-      break;                                                  \
-    }                                                         \
-    case MaskMode::kMultiItemScoring: {                       \
+#define DISPATCH_MASK_MODE(mask_mode, MASK_MODE, ...)             \
+  switch (mask_mode) {                                            \
+    case MaskMode::kNone: {                                       \
+      constexpr MaskMode MASK_MODE = MaskMode::kNone;             \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCausal: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCausal;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCustom: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCustom;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kMultiItemScoring: {                           \
       constexpr MaskMode MASK_MODE = MaskMode::kMultiItemScoring; \
-      __VA_ARGS__                                             \
-      break;                                                  \
-    }                                                         \
-    default: {                                                \
-      std::ostringstream err_msg;                             \
-      err_msg << "Unsupported mask_mode: " << int(mask_mode); \
-      FLASHINFER_ERROR(err_msg.str());                        \
-    }                                                         \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    default: {                                                    \
+      std::ostringstream err_msg;                                 \
+      err_msg << "Unsupported mask_mode: " << int(mask_mode);     \
+      FLASHINFER_ERROR(err_msg.str());                            \
+    }                                                             \
   }
 
 // convert head_dim to compile-time constant

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ head_dims_sm90.extend(
     [(k, v) for k, v in SM90_ALLOWED_HEAD_DIMS if k != v]
 )  # Always enable (192,128)
 
-mask_modes = [0, 1, 2]
+mask_modes = [0, 1, 2, 3]
 
 enable_aot = os.environ.get("FLASHINFER_ENABLE_AOT", "0") == "1"
 enable_f16 = os.environ.get("FLASHINFER_ENABLE_F16", "1") == "1"
@@ -227,6 +227,7 @@ if enable_aot:
         "-use_fast_math",
         "-DNDEBUG",
         "-DPy_LIMITED_API=0x03080000",
+        "-lineinfo"
     ]
     libraries = [
         "cublas",

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ if enable_aot:
         "-use_fast_math",
         "-DNDEBUG",
         "-DPy_LIMITED_API=0x03080000",
-        "-lineinfo"
+        "-lineinfo",
     ]
     libraries = [
         "cublas",

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -435,9 +435,9 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapper(
     paged_kv_t<DTypeKV, IdType> paged_kv, DTypeO* o, float* lse, uint32_t num_qo_heads,
     bool causal = true, PosEncodingMode pos_encoding_mode = PosEncodingMode::kNone,
     bool use_fp16_qk_reduction = false, std::optional<float> maybe_sm_scale = std::nullopt,
-    float rope_scale = 1.f, float rope_theta = 1e4,
-    cudaStream_t stream = nullptr,
-    uint32_t* prefix_len_ptr, uint16_t* token_pos_in_items_ptr, uint32_t token_pos_in_items_len, uint16_t* max_item_len_ptr) {
+    float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr,
+    uint32_t* prefix_len_ptr, uint16_t* token_pos_in_items_ptr, uint32_t token_pos_in_items_len,
+    uint16_t* max_item_len_ptr) {
   const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(paged_kv.head_dim)));
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;

--- a/src/flashinfer_ops.cuh
+++ b/src/flashinfer_ops.cuh
@@ -435,11 +435,14 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapper(
     paged_kv_t<DTypeKV, IdType> paged_kv, DTypeO* o, float* lse, uint32_t num_qo_heads,
     bool causal = true, PosEncodingMode pos_encoding_mode = PosEncodingMode::kNone,
     bool use_fp16_qk_reduction = false, std::optional<float> maybe_sm_scale = std::nullopt,
-    float rope_scale = 1.f, float rope_theta = 1e4, cudaStream_t stream = nullptr) {
+    float rope_scale = 1.f, float rope_theta = 1e4,
+    cudaStream_t stream = nullptr,
+    uint32_t* prefix_len_ptr, uint16_t* token_pos_in_items_ptr, uint32_t token_pos_in_items_len, uint16_t* max_item_len_ptr) {
   const float sm_scale = maybe_sm_scale.value_or(1.f / std::sqrt(float(paged_kv.head_dim)));
   const uint32_t num_kv_heads = paged_kv.num_heads;
   const uint32_t head_dim = paged_kv.head_dim;
-  const MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
+  MaskMode mask_mode = causal ? MaskMode::kCausal : MaskMode::kNone;
+  if (prefix_len_ptr != nullptr) mask_mode = MaskMode::kMultiItemScoring;
   auto plan_info = handler->GetPlanInfo();
   DISPATCH_head_dim(
       head_dim, HEAD_DIM,
@@ -470,6 +473,10 @@ cudaError_t BatchPrefillWithPagedKVCacheWrapper(
                 params.max_total_num_rows = plan_info.total_num_rows;
                 params.total_num_rows = handler->GetTotalNumRows();
                 params.padded_batch_size = plan_info.padded_batch_size;
+                params.prefix_len_ptr = prefix_len_ptr;
+                params.token_pos_in_items_ptr = token_pos_in_items_ptr;
+                params.token_pos_in_items_len = token_pos_in_items_len;
+                params.max_item_len_ptr = max_item_len_ptr;
                 DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
                   return BatchPrefillWithPagedKVCacheDispatched<
                       CTA_TILE_Q, HEAD_DIM, HEAD_DIM, POS_ENCODING_MODE, USE_FP16_QK_REDUCTION,

--- a/tests/test_batch_prefill_kernels.py
+++ b/tests/test_batch_prefill_kernels.py
@@ -19,6 +19,7 @@ import torch
 from jit_utils import jit_prefill_attention_func_args
 
 import flashinfer
+import numpy
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -801,6 +802,195 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
     else:
         o_causal = wrapper.run(q, k, v)
     torch.testing.assert_close(o_custom, o_causal, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize(
+    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    [
+        (54, 37, 17, list(range(17)) + list(range(19)) + [0], 100, [18]),
+        (97, 81, 16, list(range(80)) + [0], 97, [79]),
+    ]
+)
+@pytest.mark.parametrize("page_size", [1, 5, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [True])
+@pytest.mark.parametrize("kv_layout", ["NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["ROPE_LLAMA"])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("return_lse", [True, False])
+def test_batch_prefill_with_paged_kv_cache_multi_item_scoring(
+    batch_size,
+    kv_len,
+    qo_len,
+    prefix_len_ptr,
+    token_pos_in_items_ptr,
+    token_pos_in_items_len,
+    max_item_len_ptr,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    causal,
+    kv_layout,
+    pos_encoding_mode,
+    logits_soft_cap,
+    return_lse,
+):
+    q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
+    q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0).half()
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim)
+        .to(0)
+        .half()
+    )
+    kv_indptr_cpu = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
+    kv_indices_cpu = torch.arange(0, total_num_pages).int()
+    kv_last_page_len_cpu = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+    q_indptr_gpu = q_indptr_cpu.to(0)
+    kv_indptr_gpu = kv_indptr_cpu.to(0)
+    kv_indices_gpu = kv_indices_cpu.to(0)
+    kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
+    wrapper.plan(
+        q_indptr_gpu,
+        kv_indptr_gpu,
+        kv_indices_gpu,
+        kv_last_page_len_gpu,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        pos_encoding_mode=pos_encoding_mode,
+        logits_soft_cap=logits_soft_cap,
+        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+    )
+    if return_lse:
+        o, _ = wrapper.run_return_lse(q, kv_data)
+    else:
+        o = wrapper.run(q, kv_data)
+
+    for i in range(batch_size):
+        perm_dims = [0, 2, 1, 3] if kv_layout == "HND" else [0, 1, 2, 3]
+        perm_dims_last = [1, 0, 2] if kv_layout == "HND" else [0, 1, 2]
+        qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
+        ki = torch.cat(
+            [
+                kv_data[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 0]
+                .permute(*perm_dims)
+                .reshape(-1, num_kv_heads, head_dim),
+                (
+                    kv_data[kv_indptr_cpu[i + 1] - 1, 0, :, : kv_last_page_len_cpu[i]]
+                    if kv_layout == "HND"
+                    else kv_data[
+                        kv_indptr_cpu[i + 1] - 1, 0, : kv_last_page_len_cpu[i], :
+                    ]
+                )
+                .permute(*perm_dims_last)
+                .reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        )
+        vi = torch.cat(
+            [
+                kv_data[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 1]
+                .permute(*perm_dims)
+                .reshape(-1, num_kv_heads, head_dim),
+                (
+                    kv_data[kv_indptr_cpu[i + 1] - 1, 1, :, : kv_last_page_len_cpu[i]]
+                    if kv_layout == "HND"
+                    else kv_data[
+                        kv_indptr_cpu[i + 1] - 1, 1, : kv_last_page_len_cpu[i], :
+                    ]
+                )
+                .permute(*perm_dims_last)
+                .reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        )
+
+        def create_2D_multi_item_mask_dense(is_delimiter, sliding_window_size=-1, prefix_cache_len=None):
+            # Function to create custom_mask for multi-item scoring
+            #
+            # Note, sliding window implementation assumes that candidate_i_size < sliding_window_size < prefix_size
+            # Args:
+            # is_delimiter: a boolen torch vec to indicate the delimiter position for creating custom attnetion mask in multi-item scoring
+            #           currently assume qo len and kv len are the same and 1D (bsz=1) case
+            # sliding_window_size: the window size for sliding window attention, -1 means no sliding window attention
+            delimiter_idx = is_delimiter.nonzero(as_tuple=True)[0]
+            if len(delimiter_idx) == 0:
+                return None
+            else:
+                first_delimiter_pos = delimiter_idx[0]
+            seq_len = len(is_delimiter)
+            pos = torch.arange(seq_len, device=is_delimiter.device)
+
+            group_ids = torch.cumsum(is_delimiter, 0)
+            # Get mask for within-group causal attention
+            within_group_causal = (group_ids.unsqueeze(1) == group_ids.unsqueeze(0)) & (pos.unsqueeze(0) <= pos.unsqueeze(1))
+            # Combine all conditions
+            attention_mask = (
+                within_group_causal |
+                ((pos >= first_delimiter_pos).unsqueeze(1) & (pos < first_delimiter_pos).unsqueeze(0))  # Prefix attention
+            ) & ~is_delimiter.unsqueeze(0) & ~is_delimiter.unsqueeze(1)  # No delimiter attention
+
+            if sliding_window_size > 0 and sliding_window_size < len(is_delimiter):
+                # Calculate how many positions from right of prefix each token can attend to
+
+                group_size = torch.sum(within_group_causal & ~is_delimiter.unsqueeze(0), dim=1)
+
+                # For prefix: after sliding_window_size position, can see window_size tokens
+                # For candidate items: can see (sliding_window_size - group_size) tokens from prefix end
+                prefix_window = torch.where(
+                    pos >= first_delimiter_pos,
+                    sliding_window_size - group_size,
+                    torch.where(
+                        pos < sliding_window_size,
+                        first_delimiter_pos,
+                        sliding_window_size
+                    )
+                )
+
+                # Starting index of attention window relative to token position for candidate item/group
+                prefix_start = first_delimiter_pos - prefix_window.unsqueeze(1)
+
+                attention_mask = attention_mask & (pos >= prefix_start)
+            if prefix_cache_len:
+                patch = torch.ones(seq_len, prefix_cache_len, device=is_delimiter.device, dtype=torch.bool)
+                attention_mask = torch.concat([patch, attention_mask], dim=1)
+            return attention_mask.unsqueeze(0).reshape(-1)
+
+        custom_mask = create_2D_multi_item_mask_dense(is_delimiter=torch.tensor(token_pos_in_items_ptr).to(0) == 0,
+                                        sliding_window_size=-1,
+                                        prefix_cache_len=prefix_len_ptr)
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
+            qi,
+            ki,
+            vi,
+            causal=causal,
+            pos_encoding_mode=pos_encoding_mode,
+            logits_soft_cap=logits_soft_cap,
+            custom_mask=custom_mask,
+        )
+        o_i_np = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]].cpu().numpy()
+        o_ref_i_np = o_ref_i.cpu().numpy()
+        numpy.testing.assert_allclose(o_i_np, o_ref_i_np, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_hopper.py
+++ b/tests/test_hopper.py
@@ -296,6 +296,214 @@ def test_batch_paged_prefill(
     torch.testing.assert_close(o_sm80, o_sm90, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("batch_size", [1])
+@pytest.mark.parametrize(
+    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    [
+        (54, 37, 17, list(range(17)) + list(range(19)) + [0], 100, [18]),
+        (97, 81, 16, list(range(80)) + [0], 97, [79]),
+    ]
+)
+@pytest.mark.parametrize("page_size", [1, 5, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [True])
+@pytest.mark.parametrize("kv_layout", ["NHD"])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("return_lse", [True, False])
+def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
+    batch_size,
+    kv_len,
+    qo_len,
+    prefix_len_ptr,
+    token_pos_in_items_ptr,
+    token_pos_in_items_len,
+    max_item_len_ptr,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    causal,
+    kv_layout,
+    logits_soft_cap,
+    return_lse,
+):
+
+    q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
+    q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0).half()
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim)
+        .to(0)
+        .half()
+    )
+    kv_indptr_cpu = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
+    kv_indices_cpu = torch.arange(0, total_num_pages).int()
+    kv_last_page_len_cpu = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+    q_indptr_gpu = q_indptr_cpu.to(0)
+    kv_indptr_gpu = kv_indptr_cpu.to(0)
+    kv_indices_gpu = kv_indices_cpu.to(0)
+    kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
+
+    wrapper_fa2 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout,  backend="fa2"
+    )
+    wrapper_fa2.plan(
+        q_indptr_gpu,
+        kv_indptr_gpu,
+        kv_indices_gpu,
+        kv_last_page_len_gpu,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+    )
+    o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
+
+    wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout,  backend="fa3"
+    )
+    wrapper_fa3.plan(
+        q_indptr_gpu,
+        kv_indptr_gpu,
+        kv_indices_gpu,
+        kv_last_page_len_gpu,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+    )
+
+    o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
+
+    torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(o_fa2, o_fa3, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize(
+    "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
+    [
+        (54, 37, [17, 17], list(range(17)) + list(range(19)) + [0] + [0]*63 + list(range(15)) + list(range(21)) + [0], 100, [18, 20]),
+        (97, 81, [16, 16], list(range(80)) + [0] + [0]*16 + list(range(76)) + [0], 97, [79, 75]),
+    ]
+)
+@pytest.mark.parametrize("page_size", [1, 5, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [True])
+@pytest.mark.parametrize("kv_layout", ["NHD"])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("return_lse", [True, False])
+def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
+    batch_size,
+    kv_len,
+    qo_len,
+    prefix_len_ptr,
+    token_pos_in_items_ptr,
+    token_pos_in_items_len,
+    max_item_len_ptr,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    causal,
+    kv_layout,
+    logits_soft_cap,
+    return_lse,
+):
+
+    q = torch.randn(batch_size * qo_len, num_qo_heads, head_dim).to(0).half()
+    q_indptr_cpu = torch.arange(0, batch_size + 1).int() * qo_len
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = (
+        torch.randn(total_num_pages, 2, num_kv_heads, page_size, head_dim).to(0).half()
+        if kv_layout == "HND"
+        else torch.randn(total_num_pages, 2, page_size, num_kv_heads, head_dim)
+        .to(0)
+        .half()
+    )
+    kv_indptr_cpu = torch.arange(0, batch_size + 1).int() * num_pages_per_seq
+    kv_indices_cpu = torch.arange(0, total_num_pages).int()
+    kv_last_page_len_cpu = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8).to(0)
+    q_indptr_gpu = q_indptr_cpu.to(0)
+    kv_indptr_gpu = kv_indptr_cpu.to(0)
+    kv_indices_gpu = kv_indices_cpu.to(0)
+    kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
+
+    wrapper_fa2 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout,  backend="fa2"
+    )
+    wrapper_fa2.plan(
+        q_indptr_gpu,
+        kv_indptr_gpu,
+        kv_indices_gpu,
+        kv_last_page_len_gpu,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+    )
+    o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
+
+    wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout,  backend="fa3"
+    )
+    wrapper_fa3.plan(
+        q_indptr_gpu,
+        kv_indptr_gpu,
+        kv_indices_gpu,
+        kv_last_page_len_gpu,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        logits_soft_cap=logits_soft_cap,
+        prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
+    )
+
+    o_fa3, lse_fa3 = wrapper_fa3.run_return_lse(q, kv_data)
+
+    torch.testing.assert_close(lse_fa2, lse_fa3, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(o_fa2, o_fa3, rtol=1e-3, atol=1e-3)
+
+
 if __name__ == "__main__":
     # test_batch_prefill(14, 64, 32, 32, False, 128)
     # test_batch_prefill(1, 32767, 8, 8, True, 128)

--- a/tests/test_hopper.py
+++ b/tests/test_hopper.py
@@ -302,7 +302,7 @@ def test_batch_paged_prefill(
     [
         (54, 37, 17, list(range(17)) + list(range(19)) + [0], 100, [18]),
         (97, 81, 16, list(range(80)) + [0], 97, [79]),
-    ]
+    ],
 )
 @pytest.mark.parametrize("page_size", [1, 5, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
@@ -354,7 +354,7 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
     kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
 
     wrapper_fa2 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout,  backend="fa2"
+        workspace_buffer, kv_layout, backend="fa2"
     )
     wrapper_fa2.plan(
         q_indptr_gpu,
@@ -368,14 +368,18 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
         causal=causal,
         logits_soft_cap=logits_soft_cap,
         prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
-        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
+        .to(dtype=torch.uint16)
+        .to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len)
+        .to(dtype=torch.uint32)
+        .to(0),
         max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
     )
     o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
 
     wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout,  backend="fa3"
+        workspace_buffer, kv_layout, backend="fa3"
     )
     wrapper_fa3.plan(
         q_indptr_gpu,
@@ -389,8 +393,12 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
         causal=causal,
         logits_soft_cap=logits_soft_cap,
         prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
-        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
+        .to(dtype=torch.uint16)
+        .to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len)
+        .to(dtype=torch.uint32)
+        .to(0),
         max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
     )
 
@@ -404,9 +412,29 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3(
 @pytest.mark.parametrize(
     "kv_len, qo_len, prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr",
     [
-        (54, 37, [17, 17], list(range(17)) + list(range(19)) + [0] + [0]*63 + list(range(15)) + list(range(21)) + [0], 100, [18, 20]),
-        (97, 81, [16, 16], list(range(80)) + [0] + [0]*16 + list(range(76)) + [0], 97, [79, 75]),
-    ]
+        (
+            54,
+            37,
+            [17, 17],
+            list(range(17))
+            + list(range(19))
+            + [0]
+            + [0] * 63
+            + list(range(15))
+            + list(range(21))
+            + [0],
+            100,
+            [18, 20],
+        ),
+        (
+            97,
+            81,
+            [16, 16],
+            list(range(80)) + [0] + [0] * 16 + list(range(76)) + [0],
+            97,
+            [79, 75],
+        ),
+    ],
 )
 @pytest.mark.parametrize("page_size", [1, 5, 16])
 @pytest.mark.parametrize("num_kv_heads", [4])
@@ -458,7 +486,7 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
     kv_last_page_len_gpu = kv_last_page_len_cpu.to(0)
 
     wrapper_fa2 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout,  backend="fa2"
+        workspace_buffer, kv_layout, backend="fa2"
     )
     wrapper_fa2.plan(
         q_indptr_gpu,
@@ -472,14 +500,18 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
         causal=causal,
         logits_soft_cap=logits_soft_cap,
         prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
-        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
+        .to(dtype=torch.uint16)
+        .to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len)
+        .to(dtype=torch.uint32)
+        .to(0),
         max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
     )
     o_fa2, lse_fa2 = wrapper_fa2.run_return_lse(q, kv_data)
 
     wrapper_fa3 = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout,  backend="fa3"
+        workspace_buffer, kv_layout, backend="fa3"
     )
     wrapper_fa3.plan(
         q_indptr_gpu,
@@ -493,8 +525,12 @@ def test_batch_prefill_with_paged_kv_cache_multi_item_scoring_fa3_bsz2(
         causal=causal,
         logits_soft_cap=logits_soft_cap,
         prefix_len_ptr=torch.tensor(prefix_len_ptr).to(dtype=torch.uint32).to(0),
-        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr).to(dtype=torch.uint16).to(0),
-        token_pos_in_items_len=torch.tensor(token_pos_in_items_len).to(dtype=torch.uint32).to(0),
+        token_pos_in_items_ptr=torch.tensor(token_pos_in_items_ptr)
+        .to(dtype=torch.uint16)
+        .to(0),
+        token_pos_in_items_len=torch.tensor(token_pos_in_items_len)
+        .to(dtype=torch.uint32)
+        .to(0),
         max_item_len_ptr=torch.tensor(max_item_len_ptr).to(dtype=torch.uint16).to(0),
     )
 

--- a/tvm_binding/batch_prefill.cu
+++ b/tvm_binding/batch_prefill.cu
@@ -44,7 +44,9 @@ IntTuple BatchPrefillWithKVCachePlan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream) {
+    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream,
+    std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer->shape[0] * DataType(float_workspace_buffer->dtype).bytes();
   size_t int_workspace_size_in_bytes =
@@ -53,6 +55,11 @@ IntTuple BatchPrefillWithKVCachePlan(
   PrefillPlanInfo plan_info;
 
   cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
+   // Check if the optional values have a value before accessing them
+  auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
+  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
   cudaError_t status = PrefillPlan<IdType>(
       static_cast<char*>(float_workspace_buffer->data) + float_workspace_buffer->byte_offset,
       float_workspace_size_in_bytes,
@@ -64,7 +71,8 @@ IntTuple BatchPrefillWithKVCachePlan(
       static_cast<IdType*>(kv_indptr->data) + kv_indptr->byte_offset / sizeof(IdType),
       total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
       enable_cuda_graph,
-      /*sizeof_dtype_o=*/2, stream);
+      /*sizeof_dtype_o=*/2, stream,
+       prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
 
   CHECK(status == cudaSuccess) << "Failed to plan prefill with error: "
                                << cudaGetErrorString(status);
@@ -174,6 +182,12 @@ void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
         params.max_total_num_rows = 0;
         params.padded_batch_size = 0;
         params.partition_kv = false;
+
+         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 
@@ -333,6 +347,12 @@ void BatchPrefillWithPagedKVCacheRun(DLTensor* float_workspace_buffer,
         params.max_total_num_rows = 0;
         params.padded_batch_size = 0;
         params.partition_kv = false;
+
+         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 

--- a/tvm_binding/batch_prefill.cu
+++ b/tvm_binding/batch_prefill.cu
@@ -55,10 +55,12 @@ IntTuple BatchPrefillWithKVCachePlan(
   PrefillPlanInfo plan_info;
 
   cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
-   // Check if the optional values have a value before accessing them
+  // Check if the optional values have a value before accessing them
   auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
-  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
-  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* token_pos_in_items_p =
+      token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v =
+      token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
   auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
   cudaError_t status = PrefillPlan<IdType>(
       static_cast<char*>(float_workspace_buffer->data) + float_workspace_buffer->byte_offset,
@@ -71,8 +73,8 @@ IntTuple BatchPrefillWithKVCachePlan(
       static_cast<IdType*>(kv_indptr->data) + kv_indptr->byte_offset / sizeof(IdType),
       total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
       enable_cuda_graph,
-      /*sizeof_dtype_o=*/2, stream,
-       prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
+      /*sizeof_dtype_o=*/2, stream, prefix_len_p, token_pos_in_items_p, token_pos_in_items_v,
+      max_item_len_p);
 
   CHECK(status == cudaSuccess) << "Failed to plan prefill with error: "
                                << cudaGetErrorString(status);
@@ -183,9 +185,10 @@ void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
         params.padded_batch_size = 0;
         params.partition_kv = false;
 
-         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
@@ -348,9 +351,10 @@ void BatchPrefillWithPagedKVCacheRun(DLTensor* float_workspace_buffer,
         params.padded_batch_size = 0;
         params.partition_kv = false;
 
-         // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
+        // set the prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr
         params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
-        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_ptr =
+            reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
         params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
         params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 

--- a/tvm_binding/batch_prefill_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_jit_tvm_binding.cu
@@ -16,16 +16,14 @@
 #include "batch_prefill_config.inc"
 #include "tvm_binding_utils.h"
 
-IntTuple BatchPrefillWithKVCachePlan(DLTensor* float_workspace_buffer,
-                                     DLTensor* int_workspace_buffer,
-                                     DLTensor* page_locked_int_workspace_buffer,
-                                     DLTensor* qo_indptr, DLTensor* kv_indptr, IntTuple kv_len_arr,
-                                     int64_t total_num_rows, int64_t batch_size,
-                                     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
-                                     bool enable_cuda_graph, int64_t head_dim_qk,
-                                     int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream,
-                                     std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
-                                     std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
+IntTuple BatchPrefillWithKVCachePlan(
+    DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer,
+    DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
+    IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
+    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream,
+    std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
                                       DLTensor* int_workspace_buffer, IntTuple plan_info_vec,

--- a/tvm_binding/batch_prefill_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_jit_tvm_binding.cu
@@ -23,7 +23,9 @@ IntTuple BatchPrefillWithKVCachePlan(DLTensor* float_workspace_buffer,
                                      int64_t total_num_rows, int64_t batch_size,
                                      int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
                                      bool enable_cuda_graph, int64_t head_dim_qk,
-                                     int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream);
+                                     int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream,
+                                     std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+                                     std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheRun(DLTensor* float_workspace_buffer,
                                       DLTensor* int_workspace_buffer, IntTuple plan_info_vec,

--- a/tvm_binding/batch_prefill_sm90.cu
+++ b/tvm_binding/batch_prefill_sm90.cu
@@ -43,7 +43,8 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream) {
+    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer->shape[0] * DataType(float_workspace_buffer->dtype).bytes();
   size_t int_workspace_size_in_bytes =
@@ -53,7 +54,11 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
   flashinfer::PrefillPlanSM90Info plan_info;
 
   cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
-
+  // Check if the optional values have a value before accessing them
+  auto* prefix_len_p = prefix_len_ptr.has_value() ? prefix_len_ptr->data_ptr() : nullptr;
+  auto* token_pos_in_items_p = token_pos_in_items_ptr.has_value() ? token_pos_in_items_ptr->data_ptr() : nullptr;
+  auto token_pos_in_items_v = token_pos_in_items_len.has_value() ? token_pos_in_items_len.value() : 0;
+  auto* max_item_len_p = max_item_len_ptr.has_value() ? max_item_len_ptr->data_ptr() : nullptr;
   cudaError_t status = PrefillSM90Plan(
       static_cast<char*>(float_workspace_buffer->data) + float_workspace_buffer->byte_offset,
       float_workspace_size_in_bytes,
@@ -65,7 +70,8 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
       static_cast<IdType*>(kv_indptr->data) + kv_indptr->byte_offset / sizeof(IdType),
       kv_len_vec.data(), total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk,
       head_dim_vo, page_size, causal, enable_cuda_graph,
-      /*sizeof_dtype_o=*/2, stream);
+      /*sizeof_dtype_o=*/2, stream,
+      prefix_len_p, token_pos_in_items_p, token_pos_in_items_v, max_item_len_p);
 
   CHECK(status == cudaSuccess) << "PrefillSM90Plan failed with error: "
                                << cudaGetErrorString(status);
@@ -175,6 +181,12 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.head_indices_offset);
         params.work_indptr =
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
+
+        // Set the multi-item scoring parameters
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 
@@ -307,6 +319,12 @@ void BatchPrefillWithPagedKVCacheSM90Run(
             GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.work_indptr_offset);
         params.kv_indices = static_cast<IdType*>(paged_kv_indices->data) +
                             paged_kv_indices->byte_offset / sizeof(IdType);
+
+         // Set the multi-item scoring parameters
+        params.prefix_len_ptr = reinterpret_cast<uint32_t*>(plan_info.prefix_len_ptr);
+        params.token_pos_in_items_ptr = reinterpret_cast<uint16_t*>(plan_info.token_pos_in_items_ptr);
+        params.token_pos_in_items_len = static_cast<uint32_t>(plan_info.token_pos_in_items_len);
+        params.max_item_len_ptr = reinterpret_cast<uint16_t*>(plan_info.max_item_len_ptr);
 
         ADDITIONAL_PARAMS_SETTER
 

--- a/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
@@ -21,7 +21,8 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream,
+    std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
     std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(

--- a/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
+++ b/tvm_binding/batch_prefill_sm90_jit_tvm_binding.cu
@@ -21,7 +21,8 @@ IntTuple BatchPrefillWithKVCacheSM90Plan(
     DLTensor* page_locked_int_workspace_buffer, DLTensor* qo_indptr, DLTensor* kv_indptr,
     IntTuple kv_len_arr, int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads,
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
-    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream);
+    int64_t head_dim_vo, bool causal, TVMStreamHandle cuda_stream, std::optional<at::Tensor> prefix_len_ptr, std::optional<at::Tensor> token_pos_in_items_ptr,
+    std::optional<int64_t> token_pos_in_items_len, std::optional<at::Tensor> max_item_len_ptr);
 
 void BatchPrefillWithRaggedKVCacheSM90Run(
     DLTensor* float_workspace_buffer, DLTensor* int_workspace_buffer, IntTuple plan_info_vec,


### PR DESCRIPTION
Co-authored with Qingquan Song (@qingquansong) and Ziang Li (@zianglih )

**Multi-item scoring** 
1. concatenate multiple candidates of a same member with all ranking candidates with delimiter separation.
<member prefix (profile & history)> + <delimiter> + <item1> + <delimiter> + item 2 + ... + item N <delimiter>
2. Extract the logits of the hidden states of the tokens before each delimiter token and extract the log prob of given label tokens. For each single prompt, output returned will be a 2D list with shape N * K where N is the number of candidate it contains and K is the number of choices we provided to the server engine (e.g., 2 for ["Yes", "No"])) (mainly done in the logit processor)
![image](https://github.com/user-attachments/assets/837ea448-99e0-4e75-b6ec-5d7bf89b53dc)

The PR optimized the multi-item scoring attention by passing four new args and use it to check the masking condition. The provided args are:
```
prefix_len_ptr :Optional[torch.Tensor]
    prefix length. A uint32 1D tensor indicating the prefix length of each prompt. The tensor size is equal to the batch size.
token_pos_in_items_ptr : Optional[float]
    A uint16 1D tensor (it will be converted to uint16 in flashinfer) indicating the token position of each item and started from 0 (delimiter)
    for each item. E.g., if we have 3 items of length 3, 2, 4 respectively for this member. This vector will be looking like
    `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0]` with 4 delimiters indexed as 0. For batch size > 1,
    we will concat them as 1D with zero paddings to make sure each has the same length, the padding length is defined by
    `token_pos_in_items_len` - length of the raw `token_pos_in_items_ptr` for each prompt.
token_pos_in_items_len : Optional[int]
    zero padding length for `token_pos_in_items_ptr` to better handle the bsz > 1 case. Still using the above 3,2,4 example.
    If we set `token_pos_in_items_len` to be 20, it will be  `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0]`
    with 7 padded zeros. (note there're 8 zeros in the end where the first one is the delimiter token 0 in the end of the prompt)
max_item_len_ptr : Optional[float]
    a uint16 vector contains the max token length of all items for each prompt
```

**Optimizations**
1. Implement efficient multi-item scoring mask for FA2 and FA3.
2. Enhance FA3  to support batch-idx for the multi-item scoring mask.
3. Implement skip tiles for FA2 and FA3 multi-item scoring
4. Optimize mask by preloading to L1 cache for thread register. 